### PR TITLE
[WIP] Load dumped frames with DALI to pytorch superres example.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "examples/pytorch_superres/flownet2-pytorch"]
 	path = examples/pytorch_superres/flownet2-pytorch
-	url = https://github.com/NVIDIA/flownet2-pytorch
+	url = https://github.com/klecki/flownet2-pytorch
 	ignore = untracked

--- a/examples/pytorch_superres/dataloading/dataloaders.py
+++ b/examples/pytorch_superres/dataloading/dataloaders.py
@@ -84,7 +84,7 @@ def get_loader(args):
             args.batchsize,
             args.world_size)
 
-        sampler = torch.utils.data.sampler.SequentialSampler(dataset)
+        sampler = torch.utils.data.sampler.RandomSampler(dataset)
 
         train_loader = DataLoader(
             dataset,
@@ -106,7 +106,7 @@ def get_loader(args):
             args.batchsize,
             args.world_size)
 
-        sampler = torch.utils.data.sampler.SequentialSampler(dataset)
+        sampler = torch.utils.data.sampler.RandomSampler(dataset)
 
         val_loader = DataLoader(
             dataset,
@@ -148,9 +148,13 @@ def get_loader(args):
         val_batches = len(val_loader)
 
         sampler = None
+    
+    # elif args.loader == 'DALI':
+
 
     else:
 
         raise ValueError('%s is not a valid option for --loader' % args.loader)
 
+    print(train_loader, train_batches, val_loader, val_batches)
     return train_loader, train_batches, val_loader, val_batches, sampler

--- a/examples/pytorch_superres/dataloading/dataloaders.py
+++ b/examples/pytorch_superres/dataloading/dataloaders.py
@@ -84,7 +84,7 @@ def get_loader(args):
             args.batchsize,
             args.world_size)
 
-        sampler = torch.utils.data.distributed.DistributedSampler(dataset)
+        sampler = torch.utils.data.sampler.SequentialSampler(dataset)
 
         train_loader = DataLoader(
             dataset,
@@ -106,7 +106,7 @@ def get_loader(args):
             args.batchsize,
             args.world_size)
 
-        sampler = torch.utils.data.distributed.DistributedSampler(dataset)
+        sampler = torch.utils.data.sampler.SequentialSampler(dataset)
 
         val_loader = DataLoader(
             dataset,
@@ -128,7 +128,7 @@ def get_loader(args):
             os.path.join(args.root, 'train'),
             batchsize=args.batchsize,
             shuffle=True,
-            distributed=True,
+            distributed=False,
             device_id=args.rank % 8,
             fp16=args.fp16)
 
@@ -141,7 +141,7 @@ def get_loader(args):
             os.path.join(args.root, 'val'),
             batchsize=1,
             shuffle=True,
-            distributed=True,
+            distributed=False,
             device_id=args.rank % 8,
             fp16=args.fp16)
 

--- a/examples/pytorch_superres/docker/Dockerfile
+++ b/examples/pytorch_superres/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/pytorch:18.03-py3
+FROM nvcr.io/nvidia/pytorch:18.05-py3
 
 ARG FFMPEG_VERSION=3.4.2
 
@@ -60,6 +60,10 @@ RUN pip install --upgrade cmake && \
     apt-get remove -y pkg-config && \
     apt-get autoremove -y
 
+RUN python -m pip install --upgrade pip
 RUN pip install scikit-image tensorflow tensorboard tensorboardX
+
+COPY nvidia_dali-0.5.0.dev0-12345-cp36-cp36m-manylinux1_x86_64.whl /wheelhouse/nvidia_dali-0.5.0.dev0-12345-cp36-cp36m-manylinux1_x86_64.whl
+RUN pip install /wheelhouse/nvidia_dali-0.5.0.dev0-12345-cp36-cp36m-manylinux1_x86_64.whl
 
 WORKDIR /workspace/examples/pytorch_superres

--- a/examples/pytorch_superres/klecki_run_docker_distributed.sh
+++ b/examples/pytorch_superres/klecki_run_docker_distributed.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+export NVVL_DIR=/home/klecki/work/nvvl
+export DATA_DIR=/mnt/nvvl_data/data
+
+export NVC="NVIDIA_DRIVER_CAPABILITIES=video,compute,utility"
+
+##nvidia-docker run --rm -it --ipc=host --net=host -e $NVC -v $NVVL_DIR:/workspace -v $DATA_DIR:/data_dir  -u $(id -u):$(id -g) -p 3567:3567 -p 6006:6006 vsrnet /workspace/examples/pytorch_superres/run_distributed.sh
+##nvidia-docker run --rm -it --ipc=host -e $NVC -v $NVVL_DIR:/workspace -v $DATA_DIR:/data_dir  -u $(id -u):$(id -g) -p 3567:3567 -p 6006:6006 vsrnet /workspace/examples/pytorch_superres/run_distributed.sh
+
+#The one that I use:
+#nvidia-docker run --rm -it --ipc=host --net=host -e $NVC -v $NVVL_DIR:/workspace -v $DATA_DIR:/data_dir  -u $(id -u):$(id -g) -p 3567:3567 -p 6006:6006 vsrnet

--- a/examples/pytorch_superres/model/model.py
+++ b/examples/pytorch_superres/model/model.py
@@ -93,7 +93,7 @@ def get_grid(batchsize, rows, cols, fp16):
 
 
 def tensorboard_image(name, image, iteration, writer):
-    # Tensorboard expects NHW and handles PIL apparently
+    # Tensorboard expects CHW and handles PIL apparently
     out_im = image.data.cpu().numpy()
     writer.add_image(name, out_im, iteration)
 
@@ -107,7 +107,7 @@ class VSRNet(nn.Module):
         self.mi = floor(self.frames / 2)
 
         self.pooling = nn.AvgPool2d(4)
-        self.upsample = nn.Upsample(scale_factor=4, mode='bilinear')
+        self.upsample = nn.Upsample(scale_factor=4, mode='bilinear', align_corners=True)
 
         if fp16:
             #from FlowNetSD16 import FlowNetSD

--- a/examples/pytorch_superres/model/model.py
+++ b/examples/pytorch_superres/model/model.py
@@ -93,7 +93,8 @@ def get_grid(batchsize, rows, cols, fp16):
 
 
 def tensorboard_image(name, image, iteration, writer):
-    out_im = np.moveaxis(image.data.cpu().numpy(), 0, 2)
+    # Tensorboard expects NHW and handles PIL apparently
+    out_im = image.data.cpu().numpy()
     writer.add_image(name, out_im, iteration)
 
 

--- a/examples/pytorch_superres/run_distributed.sh
+++ b/examples/pytorch_superres/run_distributed.sh
@@ -1,17 +1,17 @@
-#!/bin/bash
+#!/bin/bash -x
 
 ###################
 # TRAINING CONFIG #
 ###################
 
-export DATA_DIR=/path/to/data/dir
+export DATA_DIR=/data_dir
 export RESOLUTION=540p  # options: 540p, 720p, 1080p, 4K
-export LOADER="NVVL"  # options: "NVVL" or "pytorch"
-export DATA_TYPE=scenes # options: "scenes" or "frames"
+export LOADER="pytorch"  # options: "NVVL" or "pytorch"
+export DATA_TYPE=frames # options: "scenes" or "frames"
 #export CODEC="h264"  #
 #export CRF="18"      # set these three only if used during preprocessing
 #export KEYINT="4"    #
-export ROOT=$DATA_DIR/$RESOLUTION/$DATA_TYPE/$CODEC/${CRF+crf$CRF}/${KEYINT+keyint$KEYINT}/
+export ROOT=$DATA_DIR/$RESOLUTION/$DATA_TYPE/ #$CODEC/${CRF+crf$CRF}/${KEYINT+keyint$KEYINT}/
 #export IS_CROPPED="--is_cropped"  # Uncomment to crop input images
 export CROP_SIZE="-1 -1"
 #export CROP_SIZE="540 960"  # Only applicable if --is_cropped uncommented
@@ -22,7 +22,7 @@ export MAXLR=0.001
 export BATCHSIZE=2
 export FRAMES=3
 export MAX_ITER=1000000
-export WS=8  # Number of GPUs available
+export WS=1  # Number of GPUs available
 export BASE_RANK=0  # Device ID of first GPU (assumes GPUs numbered sequentially)
 
 export IP=localhost
@@ -35,4 +35,4 @@ for i in `seq 0 $(($WS - 2))`; do
     export RANK=$(($WS - $i - 1))
     python main.py --loader $LOADER --rank $(($BASE_RANK + $RANK)) --batchsize $BATCHSIZE --frames $FRAMES --root $ROOT --world_size $WS --ip $IP $BENCHMARK $IS_CROPPED $FP16 --max_iter $MAX_ITER --min_lr $MINLR --max_lr $MAXLR $TIMING --crop_size $CROP_SIZE &
 done
-python main.py --loader $LOADER --rank $(($BASE_RANK)) --batchsize $BATCHSIZE --frames $FRAMES --root $ROOT --world_size $WS --ip $IP $BENCHMARK $IS_CROPPED $FP16 --max_iter $MAX_ITER --min_lr $MINLR --max_lr $MAXLR $TIMING --crop_size $CROP_SIZE
+python3 main.py --loader $LOADER --rank $(($BASE_RANK)) --batchsize $BATCHSIZE --frames $FRAMES --root $ROOT --world_size $WS --ip $IP $BENCHMARK $IS_CROPPED $FP16 --max_iter $MAX_ITER --min_lr $MINLR --max_lr $MAXLR $TIMING --crop_size $CROP_SIZE

--- a/examples/pytorch_superres/run_distributed.sh
+++ b/examples/pytorch_superres/run_distributed.sh
@@ -6,7 +6,7 @@
 
 export DATA_DIR=/data_dir
 export RESOLUTION=540p  # options: 540p, 720p, 1080p, 4K
-export LOADER="pytorch"  # options: "NVVL" or "pytorch"
+export LOADER="DALI"  # options: "NVVL" or "pytorch" or "DALI"
 export DATA_TYPE=frames # options: "scenes" or "frames"
 #export CODEC="h264"  #
 #export CRF="18"      # set these three only if used during preprocessing

--- a/examples/pytorch_superres/transcode-video.sh
+++ b/examples/pytorch_superres/transcode-video.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+python ./tools/transcode_scenes.py --master_data data --resolution 4K
+python ./tools/transcode_scenes.py --master_data data --resolution 1080p
+python ./tools/transcode_scenes.py --master_data data --resolution 720p
+python ./tools/transcode_scenes.py --master_data data --resolution 540p
+
+python ./tools/extract_frames.py --master_data data --resolution 540p
+python ./tools/extract_frames.py --master_data data --resolution 720p
+python ./tools/extract_frames.py --master_data data --resolution 1080p
+python ./tools/extract_frames.py --master_data data --resolution 4K #not sure if ok


### PR DESCRIPTION
Changes to allow NVVL pytorch superres example to run on workstation with only one GPU.

Fixes for tensorboar image output.

DALI installation and some processing scripts rely on paths to local machine that should be changed.
Added a DALI dataloader. Augmentations with numpy for now. Works in similar way to pytorch SequentalSampler.